### PR TITLE
Support docx files without footnotes

### DIFF
--- a/lib/docx_converter/parser.rb
+++ b/lib/docx_converter/parser.rb
@@ -110,7 +110,7 @@ module DocxConverter
             # Word outputs -1 and 0 as 'magic' footnotes
             next
           end
-            output[footnote_number] = parse_content(fnode,0).strip
+          output[footnote_number] = parse_content(fnode,0).strip
         end
       end
       return output

--- a/lib/docx_converter/parser.rb
+++ b/lib/docx_converter/parser.rb
@@ -56,8 +56,10 @@ module DocxConverter
     def unzip_read(zip_path)
       file = @zipfile.find_entry(zip_path)
       contents = ""
-      file.get_input_stream do |f|
-        contents = f.read
+      unless file.nil?
+        file.get_input_stream do |f|
+            contents = f.read
+        end
       end
       return contents
     end
@@ -101,13 +103,15 @@ module DocxConverter
     
     def parse_footnotes(node)
       output = {}
-      node.xpath("//w:footnote").each do |fnode|
-        footnote_number = fnode.attributes["id"].value
-        if ["-1", "0"].include?(footnote_number)
-          # Word outputs -1 and 0 as 'magic' footnotes
-          next
+      unless node.instance_variable_get(:@node_cache).empty?
+        node.xpath("//w:footnote").each do |fnode|
+          footnote_number = fnode.attributes["id"].value
+          if ["-1", "0"].include?(footnote_number)
+            # Word outputs -1 and 0 as 'magic' footnotes
+            next
+          end
+            output[footnote_number] = parse_content(fnode,0).strip
         end
-        output[footnote_number] = parse_content(fnode,0).strip
       end
       return output
     end


### PR DESCRIPTION
Firstly thanks for this awesome gem!!
I ran into a small issue on some of the docx files I tried to parse where they didn't have any footnotes. So I have added some small checks to prevent runtime errors when trying to parse these files.

**Side note:** 
I am not sure if this should be a separate pull request because I don't know a lot about ruby conventions but I had some small issues trying to get this gem to work and solved them by adding the following to my gemfile:

```
gem 'rubyzip', '< 1.0.0'
gem 'publishr',
gem 'docx_converter', '~> 1.0'
```

The newer rubyzip no longer supports this line in lib/docx_converter.rb:
`require 'zip/zipfilesystem'`
So setting it to require an older version fixed this issue.

The publisher gem is required in lib/docx_converter.rb but the publisher gem is not mentioned in the gemspec file, should this be added to the gemspec? or is it expected that users should add this manually?

When I tried adding just `gem 'docx_converter'` to my side project, bundler complained that it couldn't find the gem docx_converter  but changing it to use a specific version as mentioned above fixed that problem so I am not sure if this should be updated in the readme.

Thanks again for this gem and please go easy on me as this is my very first pull request :)
Brent

